### PR TITLE
Fix room status mbl logic by updating setting score logic

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mbl/RoomStatusMBL.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mbl/RoomStatusMBL.scala
@@ -94,6 +94,7 @@ case class RoomStatusMBL(children: Seq[Expression]) extends DeclarativeAggregate
           // 复用SumMBL，需要把这俩倒过来：
           //  房态=0时，设置分数为1；
           //  房态!=0时，设置分数为0.
+          // SumMBL中，beat为mt<comp；lose为mt>comp,所以设置如果有房，则设置成小的值；如果没有房，设置成较大的值
 
           If(weightIndex < numPoints &&
             crawlTime > startTimeInSeconds && crawlTime < endTimeInSeconds,
@@ -103,10 +104,10 @@ case class RoomStatusMBL(children: Seq[Expression]) extends DeclarativeAggregate
                 /* ignore */ Literal(true)),
               SetArrayItem(points, compScoreIndex,
                 /* 遇到compRoomStatus===0，表示有房 */
-                If(compRoomStatusScore === 1 || compRoomStatus === 0, 1, 0)),
+                If(compRoomStatusScore === 0 || compRoomStatus === 0, 0, 1)),
               SetArrayItem(points, mtScoreIndex,
                 /* 遇到mtRoomStatus===0，表示有房 */
-                If(mtRoomStatusScore === 1 || mtRoomStatus === 0, 1, 0)),
+                If(mtRoomStatusScore === 0 || mtRoomStatus === 0, 0, 1)),
               points),
             Else(
               points


### PR DESCRIPTION
## What changes were proposed in this pull request?
SumMBL中，beat为mt<comp；lose为mt>comp,所以设置如果有房，则设置成小的值；如果没有房，设置成较大的值.

## How was this patch tested?
1) mbl sql
`SELECT mt_poi_id,
      CAST(ts AS TIMESTAMP) data_version,
      meet,
      beat,
      lose,
      ROUND(meet*100/(meet+beat+lose),2) AS meet_rate,
      ROUND(beat*100/(meet+beat+lose),2) AS beat_rate,
      ROUND(lose*100/(meet+beat+lose),2) AS lose_rate,
      ROUND((ROUND(beat*100/(meet+beat+lose),2)-2*ROUND(lose*100/(meet+beat+lose),2)),2) AS mbl
 FROM (
       SELECT inline(s),
              mt_poi_id,
              mt_poi_name
         FROM (
               SELECT builtin_sum_mbl(a.cc) AS s,
                      mt_poi_id,
                      poi_name as mt_poi_name
                 FROM (
                       SELECT builtin_room_status_mbl(1515391200,1515394800,900,3600,detail.crawl_time,detail.comp_room_status,detail.mt_room_status,1) as cc,
                              detail.mt_poi_id,
                              detail.mt_room_id,
                              detail.mt_breakfast,
                              poi.poi_name
                         FROM OE_STREAM_COMP_DATA_FOR_MBL detail
                        INNER JOIN oe_dim_org bd
                           ON detail.mt_bd_id = bd.bd_id
                        INNER JOIN oe_dim_poi poi
                           ON detail.mt_poi_id = poi.mt_poi_id
                        WHERE (detail.DATEKEY = 20180108 and detail.CHECKIN_DATE = 20180108 )
                          and detail.mt_poi_id in(5359216)
                        GROUP BY detail.mt_poi_id,
                                 detail.mt_room_id,
                                 detail.mt_breakfast,
                                 poi.poi_name
                      ) AS a
                GROUP BY mt_poi_id,
                         poi_name
              )
      )`

2) detail sql
`select * from (

SELECT detail.crawl_time,
                      detail.datekey,
                      detail.checkin_date,
                      detail.mt_poi_id,
                      detail.mt_room_id,
                      detail.mt_breakfast,
                      detail.mt_goods_id,
                      detail.mt_room_status,
                      detail.comp_room_status,
                      ROW_NUMBER() OVER(partition by  detail.mt_poi_id,detail.mt_room_id,detail.mt_breakfast ORDER BY detail.comp_room_status asc, detail.mt_room_status) as rn
                 FROM OE_STREAM_COMP_DATA_FOR_MBL detail
                INNER JOIN oe_dim_org bd
                   ON detail.mt_bd_id = bd.bd_id
                INNER JOIN oe_dim_poi poi
                   ON detail.mt_poi_id = poi.mt_poi_id
                WHERE (detail.CHECKIN_DATE = 20180108  and detail.CRAWL_TIME between 1515391200 and 1515394800)
                  and detail.mt_poi_id in(5359216)


) a where a.rn = 1;`

3) compare the result to see if they are matched

Please review http://spark.apache.org/contributing.html before opening a pull request.
